### PR TITLE
fix: 恩山论坛登陆状态判断

### DIFF
--- a/EnShan.py
+++ b/EnShan.py
@@ -22,7 +22,7 @@ class EnShan:
             'Cookie': self.cookie
         }
         res = requests.get(url, headers=headers)
-        if '登录' in res.text:
+        if '您需要先登录才能继续本操作' in res.text:
             print("Cookie失效")
             self.sio.write("Cookie失效\n")
         else:


### PR DESCRIPTION
恩山论坛在 html 中增加了一个 display: none 属性的元素，内容里含有“登录”字符串，导致误判